### PR TITLE
change weekday for stuttgart event to tuesday

### DIFF
--- a/event_schedules/edgg.json
+++ b/event_schedules/edgg.json
@@ -42,7 +42,7 @@
     ]
   },
   {
-    "day": "7",
+    "day": "2",
     "booking": [
       "EDDS",
       "EDGG_DKB"


### PR DESCRIPTION
Changed weekday for Stuttgart event from sunday to tuesday. Scheduled to 15th to avoid people not booking for tomorrow or booking for 13th, as next event is supposed to happen on 20th.

/schedule 2024-02-15