### PR TITLE
Remove EDLL & EDFF schedule

### DIFF
--- a/data/edgg/afis.json
+++ b/data/edgg/afis.json
@@ -168,7 +168,6 @@
         "abbreviation": "FQI",
         "description": "Allendorf Radio",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ],
         "gcap_status": "AFIS",
@@ -348,7 +347,6 @@
         "abbreviation": "GSI",
         "description": "Siegerland Information",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ],
         "gcap_status": "AFIS",

--- a/data/edgg/afis.json
+++ b/data/edgg/afis.json
@@ -93,7 +93,6 @@
         "abbreviation": "FEI",
         "description": "Egelsbach Radio",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "AFIS",
@@ -169,7 +168,6 @@
         "abbreviation": "FQI",
         "description": "Allendorf Radio",
         "schedule_show_booked": [
-            "EDFF",
             "EDLL",
             "EDGG"
         ],
@@ -350,7 +348,6 @@
         "abbreviation": "GSI",
         "description": "Siegerland Information",
         "schedule_show_booked": [
-            "EDFF",
             "EDLL",
             "EDGG"
         ],
@@ -731,7 +728,6 @@
         "abbreviation": "QGI",
         "description": "Giebelstadt Information",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "AFIS",
@@ -911,7 +907,6 @@
         "abbreviation": "RYI",
         "description": "Speyer Radio",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "AFIS",
@@ -923,7 +918,6 @@
         "abbreviation": "RZI",
         "description": "Zweibr\u00fccken Information",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "AFIS",
@@ -1215,7 +1209,6 @@
         "abbreviation": "TYI",
         "description": "Schw\u00e4bisch Hall Information",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "AFIS",

--- a/data/edgg/app.json
+++ b/data/edgg/app.json
@@ -65,8 +65,7 @@
         "abbreviation": "DGAT",
         "description": "M\u00fcnster/Osnabr\u00fcck Arrival",
         "schedule_show_booked": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ]
     },
     {
@@ -75,8 +74,7 @@
         "abbreviation": "HMM",
         "description": "Langen Radar (Hamm)",
         "schedule_show_always": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ]
     },
     {
@@ -85,8 +83,7 @@
         "abbreviation": "DKA",
         "description": "Langen Radar (K\u00f6ln/Bonn Arrival)",
         "schedule_show_always": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "gcap_status": "1"
     },
@@ -96,7 +93,6 @@
         "abbreviation": "DKAT",
         "description": "K\u00f6ln/Bonn Arrival",
         "schedule_show_always": [
-            "EDLL",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -106,9 +102,6 @@
         "frequency": "127.365",
         "abbreviation": "NOR",
         "description": "Langen Radar (N\u00f6rvenich)",
-        "schedule_show_always": [
-            "EDLL"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -119,9 +112,6 @@
         "frequency": "121.355",
         "abbreviation": "DLD",
         "description": "Langen Radar (D\u00fcsseldorf Departure)",
-        "schedule_show_always": [
-            "EDLL"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -133,8 +123,7 @@
         "abbreviation": "DLA",
         "description": "Langen Radar (D\u00fcsseldorf Arrival)",
         "schedule_show_always": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "gcap_status": "1"
     },
@@ -143,9 +132,6 @@
         "frequency": "119.110",
         "abbreviation": "BOT",
         "description": "Langen Radar (Bottrop)",
-        "schedule_show_always": [
-            "EDLL"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -157,7 +143,6 @@
         "abbreviation": "DLAT",
         "description": "D\u00fcsseldorf Arrival",
         "schedule_show_always": [
-            "EDLL",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -222,8 +207,7 @@
         "abbreviation": "PADL",
         "description": "Langen Radar (Paderborn Low)",
         "schedule_show_booked": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ]
     }
 ]

--- a/data/edgg/app.json
+++ b/data/edgg/app.json
@@ -5,7 +5,6 @@
         "abbreviation": "DFDN",
         "description": "Langen Radar (Frankfurt Departure North)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -16,7 +15,6 @@
         "abbreviation": "DFDS",
         "description": "Langen Radar (Frankfurt Departure South)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -27,7 +25,6 @@
         "abbreviation": "DFANT",
         "description": "Frankfurt Arrival (North)",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -37,9 +34,6 @@
         "frequency": "118.505",
         "abbreviation": "DFAST",
         "description": "Frankfurt Arrival (South)",
-        "schedule_show_always": [
-            "EDFF"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -51,7 +45,6 @@
         "abbreviation": "DFAN",
         "description": "Langen Radar (Frankfurt Arrival North)",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -62,7 +55,6 @@
         "abbreviation": "DFAS",
         "description": "Langen Radar (Frankfurt Arrival South)",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -176,7 +168,6 @@
         "abbreviation": "PFA",
         "description": "Langen Radar (Pfalz)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -186,7 +177,6 @@
         "abbreviation": "DSAT",
         "description": "Stuttgart Arrival",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -196,7 +186,6 @@
         "abbreviation": "REU",
         "description": "Langen Radar (Reutlingen)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -206,7 +195,6 @@
         "abbreviation": "STG",
         "description": "Langen Radar (Stuttgart)",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -216,7 +204,6 @@
         "abbreviation": "EIF",
         "description": "Langen Radar (Eifel)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -226,7 +213,6 @@
         "abbreviation": "NKRL",
         "description": "Langen Radar (Neckar Low)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },

--- a/data/edgg/co.json
+++ b/data/edgg/co.json
@@ -15,8 +15,7 @@
         "abbreviation": "DKC",
         "description": "K\u00f6ln/Bonn Delivery Coordinator",
         "schedule_show_booked": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ]
     },
     {
@@ -25,8 +24,7 @@
         "abbreviation": "DLC",
         "description": "D\u00fcsseldorf Delivery Coordinator",
         "schedule_show_booked": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "gcap_status": "1"
     },

--- a/data/edgg/co.json
+++ b/data/edgg/co.json
@@ -5,8 +5,7 @@
         "abbreviation": "DFC",
         "description": "Frankfurt Delivery Coordinator",
         "schedule_show_booked": [
-            "EDGG",
-            "EDFF"
+            "EDGG"
         ],
         "gcap_status": "1"
     },
@@ -37,8 +36,7 @@
         "abbreviation": "DSC",
         "description": "Stuttgart Delivery Coordinator",
         "schedule_show_booked": [
-            "EDGG",
-            "EDFF"
+            "EDGG"
         ]
     }
 ]

--- a/data/edgg/ctr.json
+++ b/data/edgg/ctr.json
@@ -5,7 +5,6 @@
         "abbreviation": "BAD",
         "description": "Langen Radar (Baden)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "cpdlc_login": "EDGB"
@@ -16,7 +15,6 @@
         "abbreviation": "DKB",
         "description": "Langen Radar (Dinkelsb\u00fchl)",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ],
         "cpdlc_login": "EDGD"
@@ -27,7 +25,6 @@
         "abbreviation": "GED",
         "description": "Langen Radar (Gedern)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -37,7 +34,6 @@
         "abbreviation": "GIN",
         "description": "Langen Radar (Gie\u00dfen)",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ],
         "schedule_show_booked": [
@@ -51,7 +47,6 @@
         "abbreviation": "HAB",
         "description": "Langen Radar (Hammelburg)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -61,7 +56,6 @@
         "abbreviation": "HEF",
         "description": "Langen Radar (Hersfeld)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -71,7 +65,6 @@
         "abbreviation": "KIR",
         "description": "Langen Radar (Kirn)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -81,7 +74,6 @@
         "abbreviation": "KNG",
         "description": "Langen Radar (K\u00f6nig)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -91,7 +83,6 @@
         "abbreviation": "KTG",
         "description": "Langen Radar (Kitzingen)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG",
             "EDLL"
         ],
@@ -104,7 +95,6 @@
         "abbreviation": "LBU",
         "description": "Langen Radar (Luburg)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -114,7 +104,6 @@
         "abbreviation": "MAIN",
         "description": "Langen Radar (Main)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -124,7 +113,6 @@
         "abbreviation": "NKRH",
         "description": "Langen Radar (Neckar High)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -145,7 +133,6 @@
         "abbreviation": "PSA",
         "description": "Langen Radar (Spessart)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -155,7 +142,6 @@
         "abbreviation": "RUD",
         "description": "Langen Radar (R\u00fcdesheim)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG",
             "EDLL"
         ],
@@ -167,7 +153,6 @@
         "abbreviation": "SIG",
         "description": "Langen Radar (Siegen)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG",
             "EDLL"
         ]
@@ -178,7 +163,6 @@
         "abbreviation": "TAU",
         "description": "Langen Radar (Taunus)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG",
             "EDLL"
         ]

--- a/data/edgg/ctr.json
+++ b/data/edgg/ctr.json
@@ -36,9 +36,6 @@
         "schedule_show_always": [
             "EDGG"
         ],
-        "schedule_show_booked": [
-            "EDLL"
-        ],
         "cpdlc_login": "EDGG"
     },
     {
@@ -83,8 +80,7 @@
         "abbreviation": "KTG",
         "description": "Langen Radar (Kitzingen)",
         "schedule_show_booked": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "gcap_status": "1",
         "cpdlc_login": "EDGK"
@@ -122,7 +118,6 @@
         "abbreviation": "PADH",
         "description": "Langen Radar (Paderborn High)",
         "schedule_show_always": [
-            "EDLL",
             "EDGG"
         ],
         "cpdlc_login": "EDGP"
@@ -142,8 +137,7 @@
         "abbreviation": "RUD",
         "description": "Langen Radar (R\u00fcdesheim)",
         "schedule_show_booked": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "cpdlc_login": "EDGR"
     },
@@ -153,8 +147,7 @@
         "abbreviation": "SIG",
         "description": "Langen Radar (Siegen)",
         "schedule_show_booked": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ]
     },
     {
@@ -163,8 +156,7 @@
         "abbreviation": "TAU",
         "description": "Langen Radar (Taunus)",
         "schedule_show_booked": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ]
     }
 ]

--- a/data/edgg/del.json
+++ b/data/edgg/del.json
@@ -15,7 +15,6 @@
         "abbreviation": "DKC",
         "description": "K\u00f6ln/Bonn Delivery",
         "schedule_show_always": [
-            "EDLL",
             "EDGG"
         ]
     },
@@ -25,7 +24,6 @@
         "abbreviation": "DLC",
         "description": "D\u00fcsseldorf Delivery",
         "schedule_show_always": [
-            "EDLL",
             "EDGG"
         ],
         "gcap_status": "1"

--- a/data/edgg/del.json
+++ b/data/edgg/del.json
@@ -5,7 +5,6 @@
         "abbreviation": "DFC",
         "description": "Frankfurt Delivery",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -37,7 +36,6 @@
         "abbreviation": "DSC",
         "description": "Stuttgart Delivery",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ]
     }

--- a/data/edgg/gnd.json
+++ b/data/edgg/gnd.json
@@ -5,7 +5,6 @@
         "abbreviation": "DFGC",
         "description": "Frankfurt Apron (Center)",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -15,9 +14,6 @@
         "frequency": "121.955",
         "abbreviation": "DFGE",
         "description": "Frankfurt Apron (East)",
-        "schedule_show_always": [
-            "EDFF"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -29,7 +25,6 @@
         "abbreviation": "DFG",
         "description": "Frankfurt Ground",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -40,7 +35,6 @@
         "abbreviation": "DFGI",
         "description": "Frankfurt Deicing",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -51,7 +45,6 @@
         "abbreviation": "DFGS",
         "description": "Frankfurt Apron (South)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -61,9 +54,6 @@
         "frequency": "121.755",
         "abbreviation": "DFGW",
         "description": "Frankfurt Apron (West)",
-        "schedule_show_always": [
-            "EDFF"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -129,7 +119,6 @@
         "abbreviation": "DRG",
         "description": "Saarbr\u00fccken Ground",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -139,7 +128,6 @@
         "abbreviation": "DSG",
         "description": "Stuttgart Ground",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -155,7 +143,6 @@
         "abbreviation": "FHG",
         "description": "Hahn Ground",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },

--- a/data/edgg/gnd.json
+++ b/data/edgg/gnd.json
@@ -65,7 +65,6 @@
         "abbreviation": "DGG",
         "description": "M\u00fcnster Ground",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ]
     },
@@ -75,7 +74,6 @@
         "abbreviation": "DKG",
         "description": "K\u00f6ln/Bonn Ground",
         "schedule_show_always": [
-            "EDLL",
             "EDGG"
         ]
     },
@@ -85,7 +83,6 @@
         "abbreviation": "DKGP",
         "description": "K\u00f6ln/Bonn Apron",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ]
     },
@@ -95,7 +92,6 @@
         "abbreviation": "DLGE",
         "description": "D\u00fcsseldorf Ground (East)",
         "schedule_show_always": [
-            "EDLL",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -105,9 +101,6 @@
         "frequency": "121.680",
         "abbreviation": "DLGW",
         "description": "D\u00fcsseldorf Ground (West)",
-        "schedule_show_always": [
-            "EDLL"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -152,7 +145,6 @@
         "abbreviation": "LNG",
         "description": "M\u00f6nchengladbach Ground",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ]
     },
@@ -162,7 +154,6 @@
         "abbreviation": "LPG",
         "description": "Paderborn Ground",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ]
     },
@@ -172,7 +163,6 @@
         "abbreviation": "LWG",
         "description": "Dortmund Ground",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ]
     },

--- a/data/edgg/military.json
+++ b/data/edgg/military.json
@@ -5,7 +5,6 @@
         "abbreviation": "TADC",
         "description": "Spangdahlem Clearance",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -15,7 +14,6 @@
         "abbreviation": "TADG",
         "description": "Spangdahlem Ground",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -25,7 +23,6 @@
         "abbreviation": "TADT",
         "description": "Spangdahlem Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -35,7 +32,6 @@
         "abbreviation": "TADA",
         "description": "Spangdahlem GCA",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -45,7 +41,6 @@
         "abbreviation": "TARG",
         "description": "Ramstein Ground",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -55,7 +50,6 @@
         "abbreviation": "TART",
         "description": "Ramstein Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -65,7 +59,6 @@
         "abbreviation": "TARA",
         "description": "Ramstein GCA",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -87,7 +80,6 @@
         "abbreviation": "THFT",
         "description": "Fritzlar Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -97,7 +89,6 @@
         "abbreviation": "THFA",
         "description": "Fritzlar Radar",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -107,7 +98,6 @@
         "abbreviation": "THNT",
         "description": "Stetten Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -117,7 +107,6 @@
         "abbreviation": "THNA",
         "description": "Stetten Radar",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -179,7 +168,6 @@
         "abbreviation": "TOUG",
         "description": "Wiesbaden Ground",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -189,7 +177,6 @@
         "abbreviation": "TOUT",
         "description": "Wiesbaden Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -199,7 +186,6 @@
         "abbreviation": "TSBT",
         "description": "B\u00fcchel Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -209,7 +195,6 @@
         "abbreviation": "TSBA",
         "description": "B\u00fcchel Radarr",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     }

--- a/data/edgg/military.json
+++ b/data/edgg/military.json
@@ -128,7 +128,6 @@
         "abbreviation": "TNGT",
         "description": "Frisbee Tower",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ]
     },
@@ -138,7 +137,6 @@
         "abbreviation": "TNGA",
         "description": "Frisbee Radar",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ]
     },
@@ -148,7 +146,6 @@
         "abbreviation": "TNNT",
         "description": "N\u00f6rvenich Tower",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ]
     },
@@ -158,7 +155,6 @@
         "abbreviation": "TNNA",
         "description": "N\u00f6rvenich Radar",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ]
     },

--- a/data/edgg/twr.json
+++ b/data/edgg/twr.json
@@ -5,7 +5,6 @@
         "abbreviation": "DFTC",
         "description": "Frankfurt Tower (Center)",
         "schedule_show_always": [
-            "EDFF",
             "EDGG"
         ],
         "gcap_status": "1"
@@ -15,9 +14,6 @@
         "frequency": "136.500",
         "abbreviation": "DFTN",
         "description": "Frankfurt Tower (North)",
-        "schedule_show_always": [
-            "EDFF"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -28,9 +24,6 @@
         "frequency": "119.905",
         "abbreviation": "DFTS",
         "description": "Frankfurt Tower (South)",
-        "schedule_show_always": [
-            "EDFF"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -41,9 +34,6 @@
         "frequency": "124.855",
         "abbreviation": "DFTW",
         "description": "Frankfurt Tower (West)",
-        "schedule_show_always": [
-            "EDFF"
-        ],
         "schedule_show_booked": [
             "EDGG"
         ],
@@ -88,7 +78,6 @@
         "abbreviation": "DRT",
         "description": "Saarbr\u00fccken Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "s1_twr": true
@@ -99,8 +88,7 @@
         "abbreviation": "DST",
         "description": "Stuttgart Tower",
         "schedule_show_always": [
-            "EDGG",
-            "EDFF"
+            "EDGG"
         ]
     },
     {
@@ -109,7 +97,6 @@
         "abbreviation": "DSTV",
         "description": "Stuttgart Tower (VFR)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ]
     },
@@ -119,7 +106,6 @@
         "abbreviation": "FHT",
         "description": "Hahn Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "s1_twr": true
@@ -130,7 +116,6 @@
         "abbreviation": "FMT",
         "description": "Mannheim Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "s1_twr": true
@@ -185,7 +170,6 @@
         "abbreviation": "SBT",
         "description": "Baden Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "s1_twr": true
@@ -196,7 +180,6 @@
         "abbreviation": "TLT",
         "description": "Lahr Tower",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "s1_twr": true

--- a/data/edgg/twr.json
+++ b/data/edgg/twr.json
@@ -45,7 +45,6 @@
         "abbreviation": "DGT",
         "description": "M\u00fcnster Tower",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ],
         "s1_twr": true
@@ -56,8 +55,7 @@
         "abbreviation": "DKT",
         "description": "K\u00f6ln/Bonn Tower",
         "schedule_show_always": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "gcap_status": "1"
     },
@@ -67,8 +65,7 @@
         "abbreviation": "DLT",
         "description": "D\u00fcsseldorf Tower",
         "schedule_show_always": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "gcap_status": "1"
     },
@@ -126,7 +123,6 @@
         "abbreviation": "LNT",
         "description": "M\u00f6nchengladbach Tower",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ],
         "s1_twr": true
@@ -137,7 +133,6 @@
         "abbreviation": "LPT",
         "description": "Paderborn Tower",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ],
         "s1_twr": true
@@ -148,7 +143,6 @@
         "abbreviation": "LVT",
         "description": "Niederrhein Tower",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ],
         "s1_twr": true
@@ -159,7 +153,6 @@
         "abbreviation": "LWT",
         "description": "Dortmund Tower",
         "schedule_show_booked": [
-            "EDLL",
             "EDGG"
         ],
         "s1_twr": true

--- a/data/eduu/ctr.json
+++ b/data/eduu/ctr.json
@@ -45,7 +45,6 @@
         "abbreviation": "FFM",
         "description": "Rhein Radar (Frankfurt)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "cpdlc_login": "EDUF"
@@ -57,8 +56,7 @@
         "description": "Rhein Radar (Fulda)",
         "schedule_show_always": [
             "EDGG",
-            "EDLL",
-            "EDFF"
+            "EDLL"
         ],
         "cpdlc_login": "EDUU"
     },
@@ -88,7 +86,6 @@
         "abbreviation": "NTM",
         "description": "Rhein Radar (Nattenheim)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "cpdlc_login": "EDUN"
@@ -130,8 +127,7 @@
         "description": "Rhein Radar (S\u00f6llingen)",
         "schedule_show_always": [
             "EDGG",
-            "EDLL",
-            "EDFF"
+            "EDLL"
         ],
         "cpdlc_login": "EDUS"
     },
@@ -151,7 +147,6 @@
         "abbreviation": "TGO",
         "description": "Rhein Radar (Tango)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "cpdlc_login": "EDUT"
@@ -162,7 +157,6 @@
         "abbreviation": "WUR",
         "description": "Rhein Radar (W\u00fcrzburg)",
         "schedule_show_booked": [
-            "EDFF",
             "EDGG"
         ],
         "cpdlc_login": "EDUW"

--- a/data/eduu/ctr.json
+++ b/data/eduu/ctr.json
@@ -55,8 +55,7 @@
         "abbreviation": "FUL",
         "description": "Rhein Radar (Fulda)",
         "schedule_show_always": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "cpdlc_login": "EDUU"
     },
@@ -126,8 +125,7 @@
         "abbreviation": "SLN",
         "description": "Rhein Radar (S\u00f6llingen)",
         "schedule_show_always": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "cpdlc_login": "EDUS"
     },

--- a/data/edyy/ctr.json
+++ b/data/edyy/ctr.json
@@ -66,7 +66,6 @@
         "description": "Maastricht Radar (Muenster)",
         "schedule_show_booked": [
             "EDWW",
-            "EDLL",
             "EDGG"
         ],
         "cpdlc_login": "EDYM"
@@ -77,8 +76,7 @@
         "abbreviation": "RHR",
         "description": "Maastricht Radar (Ruhr)",
         "schedule_show_always": [
-            "EDGG",
-            "EDLL"
+            "EDGG"
         ],
         "cpdlc_login": "EDYR"
     },

--- a/data/edyy/ctr.json
+++ b/data/edyy/ctr.json
@@ -78,8 +78,7 @@
         "description": "Maastricht Radar (Ruhr)",
         "schedule_show_always": [
             "EDGG",
-            "EDLL",
-            "EDFF"
+            "EDLL"
         ],
         "cpdlc_login": "EDYR"
     },

--- a/src/classes/datahub.py
+++ b/src/classes/datahub.py
@@ -124,7 +124,7 @@ class Datahub:
     def __generate_schedules_json(self):
         inverted_schedule: List[Dict[str, List[str]]] = []
 
-        schedule_types = ["EDGG", "EDMM", "EDWW", "EDLL", "MIL"]
+        schedule_types = ["EDGG", "EDMM", "EDWW", "MIL"]
 
         for schedule_type in schedule_types:
             schedule_entry = {

--- a/src/classes/datahub.py
+++ b/src/classes/datahub.py
@@ -124,7 +124,7 @@ class Datahub:
     def __generate_schedules_json(self):
         inverted_schedule: List[Dict[str, List[str]]] = []
 
-        schedule_types = ["EDGG", "EDMM", "EDWW", "EDFF", "EDLL", "MIL"]
+        schedule_types = ["EDGG", "EDMM", "EDWW", "EDLL", "MIL"]
 
         for schedule_type in schedule_types:
             schedule_entry = {

--- a/src/views/schedules.py
+++ b/src/views/schedules.py
@@ -1,4 +1,4 @@
 from typing import Literal
 
 
-ScheduleType = Literal["EDGG", "EDMM", "EDWW", "EDFF", "EDLL"]
+ScheduleType = Literal["EDGG", "EDMM", "EDWW", "EDLL"]

--- a/src/views/schedules.py
+++ b/src/views/schedules.py
@@ -1,4 +1,4 @@
 from typing import Literal
 
 
-ScheduleType = Literal["EDGG", "EDMM", "EDWW", "EDLL"]
+ScheduleType = Literal["EDGG", "EDMM", "EDWW"]


### PR DESCRIPTION
removes all EDLL and EDFF schedule flags from all stations as both schedules have been discontinued