### PR TITLE
Make DFTW wanted instead of DFTN for events

### DIFF
--- a/data/edgg/twr.json
+++ b/data/edgg/twr.json
@@ -14,7 +14,7 @@
         "frequency": "136.500",
         "abbreviation": "DFTN",
         "description": "Frankfurt Tower (North)",
-        "schedule_show_always": [
+        "schedule_show_booked": [
             "EDGG"
         ],
         "gcap_status": "1"
@@ -34,7 +34,7 @@
         "frequency": "124.855",
         "abbreviation": "DFTW",
         "description": "Frankfurt Tower (West)",
-        "schedule_show_booked": [
+        "schedule_show_always": [
             "EDGG"
         ],
         "gcap_status": "1"


### PR DESCRIPTION
Currently, DFTC and DFTN are WANTED for events in the booking overview. This uneven split gives DFTC three runways and DFTN only one. I think a better targeted split (which is also usually booked first) is DFTC and DFTW, which gives both Towers two runways.